### PR TITLE
Removing reactnativeutilsjni as it is built from the same sources as reactnativejni

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/CMakeLists.txt
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(
         react_render_uimanager
         react_utils
         react_config
-        reactnativeutilsjni
+        reactnativejni
         rrc_image
         rrc_modal
         rrc_progressbar

--- a/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -17,32 +17,6 @@ add_compile_options(
         -std=c++17
         -DWITH_INSPECTOR=1)
 
-##########################
-### React Native Utils ###
-##########################
-
-add_library(
-        reactnativeutilsjni
-        SHARED
-        ${reactnativejni_SRC}
-)
-
-# TODO This should not be ../../
-target_include_directories(reactnativeutilsjni PUBLIC ../../)
-
-target_link_libraries(reactnativeutilsjni
-        android
-        callinvokerholder
-        fb
-        fbjni
-        folly_runtime
-        glog_init
-        react_render_runtimescheduler
-        reactnative
-        runtimeexecutor
-        yoga
-        )
-
 ######################
 ### reactnativejni ###
 ######################
@@ -67,7 +41,6 @@ target_link_libraries(reactnativejni
         logger
         react_render_runtimescheduler
         reactnative
-        reactnativeutilsjni
         runtimeexecutor
         yoga
         )

--- a/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(rrc_progressbar
         react_render_debug
         react_render_graphics
         react_render_uimanager
-        reactnativeutilsjni
+        reactnativejni
         rrc_view
         yoga
 )

--- a/ReactCommon/react/renderer/components/slider/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/slider/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(rrc_slider
         react_render_imagemanager
         react_render_mapbuffer
         react_render_uimanager
-        reactnativeutilsjni
+        reactnativejni
         rrc_image
         rrc_view
         yoga

--- a/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
         react_render_debug
         react_render_graphics
         react_render_uimanager
-        reactnativeutilsjni
+        reactnativejni
         rrc_view
         yoga
 )

--- a/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -40,6 +40,6 @@ target_link_libraries(react_render_textlayoutmanager
         react_render_telemetry
         react_render_uimanager
         react_utils
-        reactnativeutilsjni
+        reactnativejni
         yoga
 )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This Pull Request aims at removing the making of reactnativeutilsjni as it is built from the same sources as reactnativejni. It also replaces references to reactnativeutilsjni with reactnativejni.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This should get rid of `reactnativeutilsjni.so` while reusing `reactnativejni.so` in it's place. This should give us some size improvements in the finally built apk.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [REMOVED] - Removed building reactnativeutilsjni

```
##########################
### React Native Utils ###
##########################

add_library(
        reactnativeutilsjni
        SHARED
        ${reactnativejni_SRC}
)

# TODO This should not be ../../
target_include_directories(reactnativeutilsjni PUBLIC ../../)

target_link_libraries(reactnativeutilsjni
        android
        callinvokerholder
        fb
        fbjni
        folly_runtime
        glog_init
        react_render_runtimescheduler
        reactnative
        runtimeexecutor
        yoga
        )
```

[GENERAL][CHANGED] - Replaced reactnativeutilsjni with reactnativejni in `ReactAndroid/src/main/java/com/facebook/react/fabric/jni/CMakeLists.txt`

[GENERAL][CHANGED] - Replaced reactnativeutilsjni with reactnativejni in `ReactCommon/react/renderer/components/progressbar/CMakeLists.txt`

[GENERAL][CHANGED] - Replaced reactnativeutilsjni with reactnativejni in `ReactCommon/react/renderer/components/slider/CMakeLists.txt`

[GENERAL][CHANGED] - Replaced reactnativeutilsjni with reactnativejni in `ReactCommon/react/renderer/components/switch/CMakeLists.txt`

[GENERAL][CHANGED] - Replaced reactnativeutilsjni with reactnativejni in `ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
